### PR TITLE
Bug 1243298 - TypeError: can't assign to properties of (new Number(0)) in fxos-tv-modal-dialog

### DIFF
--- a/smart-input-dialog.js
+++ b/smart-input-dialog.js
@@ -182,7 +182,7 @@
     this._createButtonGroup(options);
 
     this._focusedGroupIndex = 0;
-    this._focusedGroupIndex[INPUT_GROUP_INDEX] = 0;
+    this._focusedIndex[INPUT_GROUP_INDEX] = 0;
     // Put focusable element groups into verticalGroup,
     // so we can simply navigate up/down among these groups.
     this.verticalGroup = [this.inputElements, this.buttonElements];


### PR DESCRIPTION
The patch:
- Fix the TypeError caused by wrongly accessing the _focusedGroupIndex variable as array.
  The right array to access should be the _focusedIndex variable.
